### PR TITLE
T213375 InlineHexURIHandler

### DIFF
--- a/bigdata-core/bigdata-rdf/src/java/com/bigdata/rdf/internal/InlineHexURIHandler.java
+++ b/bigdata-core/bigdata-rdf/src/java/com/bigdata/rdf/internal/InlineHexURIHandler.java
@@ -1,0 +1,92 @@
+/**
+
+Copyright (C) SYSTAP, LLC DBA Blazegraph 2006-2016.  All rights reserved.
+
+Contact:
+     SYSTAP, LLC DBA Blazegraph
+     2501 Calvert ST NW #106
+     Washington, DC 20008
+     licenses@blazegraph.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package com.bigdata.rdf.internal;
+
+import java.math.BigInteger;
+import java.util.Random;
+
+import com.bigdata.rdf.internal.impl.literal.AbstractLiteralIV;
+import com.bigdata.rdf.internal.impl.literal.XSDIntegerIV;
+import com.bigdata.rdf.model.BigdataLiteral;
+
+/**
+ *
+ * Inline URI Handler to handle URI's in the form of a Hex UUID such as:
+ *
+ *  <pre>
+ *   http://blazegraph.com/element/d95dde070543a0e0115c8d5061fce6754bb82280
+ *  </pre>
+ *
+ *  {@link https://phabricator.wikimedia.org/T213375}
+ *
+ * @author igorkim78@gmail.com
+ *
+ */
+public class InlineHexURIHandler extends InlineURIHandler {
+
+    /**
+     * Default URI namespace for inline UUIDs.
+     */
+    public static final String NAMESPACE = "urn:hex:big:";
+
+    public InlineHexURIHandler(final String namespace) {
+        super(namespace);
+    }
+
+    @SuppressWarnings("rawtypes")
+    protected AbstractLiteralIV createInlineIV(final String localName) {
+
+        if (localName == null) {
+            return null;
+        }
+
+        try {
+		Random rnd = new Random();
+            BigInteger value = new BigInteger(localName,16);
+//            for (int i = 8*20; i<8*250; i++) {
+//            	if ((rnd.nextInt()&1) == 0)
+//            	value = value.setBit(i);
+//            }
+			return new XSDIntegerIV(value);
+        } catch (IllegalArgumentException ex) {
+            /*
+             * Could not parse localName into a BigInteger.  Fall through to TermIV.
+             */
+            return null;
+        }
+
+    }
+
+    @SuppressWarnings("rawtypes")
+	@Override
+	public String getLocalNameFromDelegate(
+			AbstractLiteralIV<BigdataLiteral, ?> delegate) {
+
+	final BigInteger bigint = ((XSDIntegerIV) delegate).getInlineValue();
+
+		final String localName = bigint.toString(16);
+
+		return localName;
+	}
+}

--- a/bigdata-rdf-test/src/test/java/com/bigdata/rdf/sparql/ast/eval/TestTicketT213375.java
+++ b/bigdata-rdf-test/src/test/java/com/bigdata/rdf/sparql/ast/eval/TestTicketT213375.java
@@ -1,0 +1,86 @@
+/**
+
+Copyright (C) SYSTAP, LLC DBA Blazegraph 2013.  All rights reserved.
+
+Contact:
+     SYSTAP, LLC DBA Blazegraph
+     2501 Calvert ST NW #106
+     Washington, DC 20008
+     licenses@blazegraph.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package com.bigdata.rdf.sparql.ast.eval;
+
+import java.util.Properties;
+
+import com.bigdata.rdf.internal.NotMaterializedException;
+import com.bigdata.rdf.store.AbstractTripleStore;
+
+
+/**
+ * Test case for https://jira.blazegraph.com/browse/BLZG-1591:
+ * {@link NotMaterializedException} with ORDER BY clause (for InlineURIIvs).
+ *
+ * @author <a href="mailto:ms@metaphacts.com">Michael Schmidt</a>
+ */
+public class TestTicketT213375 extends AbstractDataDrivenSPARQLTestCase {
+
+   public TestTicketT213375() {
+   }
+
+   public TestTicketT213375(String name) {
+      super(name);
+   }
+
+
+  public void test_ticket_T213375a() throws Exception {
+     new TestHelper("ticket-T213375a",// testURI,
+           "ticket_T213375a.rq",// queryFileURL
+           "ticket_T213375.nt",// dataFileURL
+           "ticket_T213375.srx",// resultFileURL
+           false /* checkOrder */
+     ).runTest();
+     System.out.println(this.store.dumpStore());
+  }
+
+
+//  public void test_ticket_1591b() throws Exception {
+//      new TestHelper("ticket-1591b",// testURI,
+//            "ticket_1591b.rq",// queryFileURL
+//            "ticket_1591.nt",// dataFileURL
+//            "ticket_1591.srx",// resultFileURL
+//            true /* checkOrder */
+//      ).runTest();
+//   }
+
+  @Override
+  public Properties getProperties() {
+
+      // Note: clone to avoid modifying!!!
+      final Properties properties = (Properties) super.getProperties().clone();
+
+      properties.setProperty(
+          AbstractTripleStore.Options.VOCABULARY_CLASS,
+          "com.bigdata.rdf.vocab.TestVocabulary_T213375");
+
+      properties.setProperty(
+          AbstractTripleStore.Options.INLINE_URI_FACTORY_CLASS,
+          "com.bigdata.rdf.vocab.TestUriInlineFactory_T213375");
+
+      return properties;
+
+  }
+
+}

--- a/bigdata-rdf-test/src/test/java/com/bigdata/rdf/sparql/ast/eval/ticket_T213375.nt
+++ b/bigdata-rdf-test/src/test/java/com/bigdata/rdf/sparql/ast/eval/ticket_T213375.nt
@@ -1,0 +1,5 @@
+<http://s1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.com/d95dde070543a0e0115c8d5061fce6754bb82280> .
+<http://s2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://test.com/d95dde070543a0e0115c8d5061fce6754bb82281> .
+<http://s3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>  <http://test.com/d95dde070543a0e0115c8d5061fce6754bb82282> .
+<http://s4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>  <http://test.com/d95dde070543a0e0115c8d5061fce6754bb82283> .
+<http://s5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>  <http://test.com/d95dde070543a0e0115c8d5061fce6754bb82284> .

--- a/bigdata-rdf-test/src/test/java/com/bigdata/rdf/sparql/ast/eval/ticket_T213375.srx
+++ b/bigdata-rdf-test/src/test/java/com/bigdata/rdf/sparql/ast/eval/ticket_T213375.srx
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<sparql xmlns='http://www.w3.org/2005/sparql-results#'>
+    <head>
+        <variable name='s'/>
+        <variable name='o'/>
+    </head>
+    <results>
+        <result>
+            <binding name='s'><uri>http://s1</uri></binding>
+            <binding name='o'><uri>http://test.com/d95dde070543a0e0115c8d5061fce6754bb82280</uri></binding>
+        </result>
+        <result>
+            <binding name='s'><uri>http://s2</uri></binding>
+            <binding name='o'><uri>http://test.com/d95dde070543a0e0115c8d5061fce6754bb82281</uri></binding>
+        </result>
+        <result>
+            <binding name='s'><uri>http://s3</uri></binding>
+            <binding name='o'><uri>http://test.com/d95dde070543a0e0115c8d5061fce6754bb82282</uri></binding>
+        </result>
+        <result>
+            <binding name='s'><uri>http://s4</uri></binding>
+            <binding name='o'><uri>http://test.com/d95dde070543a0e0115c8d5061fce6754bb82283</uri></binding>
+        </result>
+        <result>
+            <binding name='s'><uri>http://s5</uri></binding>
+            <binding name='o'><uri>http://test.com/d95dde070543a0e0115c8d5061fce6754bb82284</uri></binding>
+        </result>
+
+    </results>
+</sparql>

--- a/bigdata-rdf-test/src/test/java/com/bigdata/rdf/sparql/ast/eval/ticket_T213375a.rq
+++ b/bigdata-rdf-test/src/test/java/com/bigdata/rdf/sparql/ast/eval/ticket_T213375a.rq
@@ -1,0 +1,3 @@
+SELECT * WHERE {
+  ?s a ?o
+} ORDER BY ?o

--- a/bigdata-rdf-test/src/test/java/com/bigdata/rdf/vocab/TestUriInlineFactory_T213375.java
+++ b/bigdata-rdf-test/src/test/java/com/bigdata/rdf/vocab/TestUriInlineFactory_T213375.java
@@ -1,0 +1,41 @@
+/**
+
+Copyright (C) SYSTAP, LLC DBA Blazegraph 2006-2016.  All rights reserved.
+
+Contact:
+     SYSTAP, LLC DBA Blazegraph
+     2501 Calvert ST NW #106
+     Washington, DC 20008
+     licenses@blazegraph.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+/*
+ * Created on Oct 28, 2007
+ */
+
+package com.bigdata.rdf.vocab;
+
+import com.bigdata.rdf.internal.InlineHexURIHandler;
+import com.bigdata.rdf.internal.InlineURIFactory;
+
+
+public class TestUriInlineFactory_T213375 extends InlineURIFactory {
+
+    public TestUriInlineFactory_T213375() {
+
+        addHandler(new InlineHexURIHandler("http://test.com/"));
+    }
+
+}

--- a/bigdata-rdf-test/src/test/java/com/bigdata/rdf/vocab/TestVocabularyDecl_T213375.java
+++ b/bigdata-rdf-test/src/test/java/com/bigdata/rdf/vocab/TestVocabularyDecl_T213375.java
@@ -1,0 +1,25 @@
+package com.bigdata.rdf.vocab;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.openrdf.model.URI;
+import org.openrdf.model.impl.URIImpl;
+
+public class TestVocabularyDecl_T213375 implements VocabularyDecl {
+
+    static private final URI[] uris = new URI[]{
+        new URIImpl("http://test.com/")
+    };
+
+    public TestVocabularyDecl_T213375() {
+    }
+
+    public Iterator<URI> values() {
+
+        return Collections.unmodifiableList(Arrays.asList(uris)).iterator();
+
+    }
+
+}

--- a/bigdata-rdf-test/src/test/java/com/bigdata/rdf/vocab/TestVocabulary_T213375.java
+++ b/bigdata-rdf-test/src/test/java/com/bigdata/rdf/vocab/TestVocabulary_T213375.java
@@ -1,0 +1,76 @@
+/**
+
+Copyright (C) SYSTAP, LLC DBA Blazegraph 2006-2016.  All rights reserved.
+
+Contact:
+     SYSTAP, LLC DBA Blazegraph
+     2501 Calvert ST NW #106
+     Washington, DC 20008
+     licenses@blazegraph.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+/*
+ * Created on Oct 28, 2007
+ */
+
+package com.bigdata.rdf.vocab;
+
+import com.bigdata.rdf.store.AbstractTripleStore;
+import com.bigdata.rdf.vocab.decls.BSBMVocabularyDecl;
+import com.bigdata.rdf.vocab.decls.DCAllVocabularyDecl;
+import com.bigdata.rdf.vocab.decls.RDFSVocabularyDecl;
+import com.bigdata.rdf.vocab.decls.RDFVocabularyDecl;
+import com.bigdata.rdf.vocab.decls.XMLSchemaVocabularyDecl;
+
+/**
+ * A {@link Vocabulary} utilizing InlineFixedWidthHexURIHandler
+ *
+ * @author <a href="mailto:igorkim78@gmail.com">Igor Kim</a>
+ * @version $Id$
+ */
+public class TestVocabulary_T213375 extends BaseVocabulary {
+
+    /**
+     * De-serialization ctor.
+     */
+    public TestVocabulary_T213375() {
+
+        super();
+
+    }
+
+    /**
+     * Used by {@link AbstractTripleStore#create()}.
+     *
+     * @param namespace
+     *            The namespace of the KB instance.
+     */
+    public TestVocabulary_T213375(final String namespace) {
+
+        super( namespace );
+
+    }
+
+    @Override
+    protected void addValues() {
+
+        addDecl(new TestVocabularyDecl_T213375());
+        addDecl(new RDFVocabularyDecl());
+        addDecl(new RDFSVocabularyDecl());
+        addDecl(new XMLSchemaVocabularyDecl());
+
+    }
+
+}


### PR DESCRIPTION
InlineHexURIHandler supports inlining of URIs per https://phabricator.wikimedia.org/T213375 with specified prefix(es) and arbitrary hex string which is encoded as BigInteger wrapped as XSDIntegerIV